### PR TITLE
Modifying _close() to no longer call exists() and stream() with possible side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # furi Changelog
 
+0.6.11
+* Bugfix so that _close() no longer calls exists() or stream() with side effects and possible exceptions
+
+0.6.10
+* Bugfix for FS walk
+
 0.6.9
 * Bugfix for stream() handling
 

--- a/furi/__init__.py
+++ b/furi/__init__.py
@@ -22,4 +22,4 @@ except ImportError:
 
 __author__ = "amancevice"
 __email__ = "smallweirdnum@gmail.com"
-__version__ = "0.6.10"
+__version__ = "0.6.11"

--- a/furi/furifile.py
+++ b/furi/furifile.py
@@ -85,7 +85,7 @@ class File(collections.Iterable):
         if self.__stream__ is not None:
             try:
                 return self.__stream__.close()
-            except:
+            except Exception:
                 pass
             finally:
                 self.__stream__ = None

--- a/furi/furifile.py
+++ b/furi/furifile.py
@@ -82,13 +82,12 @@ class File(collections.Iterable):
 
     def _close(self):
         """ Close stream implementation. """
-        if self.__stream__ is not None:
-            try:
-                return self.__stream__.close()
-            except Exception:  # pylint: disable=broad-except
-                pass
-            finally:
-                self.__stream__ = None
+        try:
+            self.__stream__.close()
+        except:  # pylint: disable=bare-except
+            pass
+        finally:
+            self.__stream__ = None
 
     def _exists(self):
         """ Test file existence implementation. """

--- a/furi/furifile.py
+++ b/furi/furifile.py
@@ -82,11 +82,13 @@ class File(collections.Iterable):
 
     def _close(self):
         """ Close stream implementation. """
-        if self.exists():
+        if self.__stream__ is not None:
             try:
-                return self.stream().close()
-            except IOError:
+                return self.__stream__.close()
+            except:
                 pass
+            finally:
+                self.__stream__ = None
 
     def _exists(self):
         """ Test file existence implementation. """

--- a/furi/furifile.py
+++ b/furi/furifile.py
@@ -85,7 +85,7 @@ class File(collections.Iterable):
         if self.__stream__ is not None:
             try:
                 return self.__stream__.close()
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 pass
             finally:
                 self.__stream__ = None


### PR DESCRIPTION
The current `_close()` calls `exists()` and, in the AWS case, `stream()`, both of which have potential side effects of trying to read the target file. Some of those side effects cause exceptions that sneak past the capture of only IOError.

`_close()` now does its best just to close the `self.__stream__` if it exists, captures all exceptions, and clears the member variable.
